### PR TITLE
Add Python wrapper around Rust wrapper for "as-native" Python usage of combine_intervals

### DIFF
--- a/examples/example_maturin.py
+++ b/examples/example_maturin.py
@@ -1,10 +1,9 @@
-from intervalues import BaseInterval, combine_intervals
+from intervalues import BaseInterval, combine_intervals, combine_via_rust
 from random import Random
-from intervalues_pyrust import combine_intervals_int, combine_intervals_float
 import time
 
 
-INTERVAL_MANY = [5, 1000, 10000, 100000, 1000000, ]
+INTERVAL_MANY = [10, 1000, 10000, 100000, 1000000, ]
 
 
 def split_to_pairs(iterable):
@@ -22,17 +21,19 @@ def combine_many(nums):
 
 
 def combine_many_rust(nums):
-    intervals = [x + (1, ) if x[0] < x[1] else (x[1], x[0], 1) for x in split_to_pairs(nums) if x[0] != x[1]]
+    intervals = [x if x[0] < x[1] else (x[1], x[0]) for x in split_to_pairs(nums)]
+    intervals = [BaseInterval(interval) for interval in intervals if interval[0] != interval[1]]
     before = time.time_ns()
-    combine_intervals_int(intervals)
+    combine_via_rust(intervals)
     after = time.time_ns()
     return (after-before)/1000000
 
 
 def combine_many_rustfl(nums):
-    intervals = [x + (1, ) if x[0] < x[1] else (x[1], x[0], 1) for x in split_to_pairs(nums) if x[0] != x[1]]
+    intervals = [x if x[0] < x[1] else (x[1], x[0]) for x in split_to_pairs(nums)]
+    intervals = [BaseInterval(interval) for interval in intervals if interval[0] != interval[1]]
     before = time.time_ns()
-    combine_intervals_float(intervals, 8)
+    combine_via_rust(intervals, 8)
     after = time.time_ns()
     return (after-before)/1000000
 
@@ -41,12 +42,11 @@ if __name__ == "__main__":
     rand_this = Random()
     for nr in INTERVAL_MANY:
         print(f"\nRun for {nr} intervals to combine")
-        nums = [rand_this.randint(0, 10) for _ in range(nr * 2)]
 
-        print('Python, ints', combine_many(nums))
-        print('Rust, ints', combine_many_rust(nums))
+        nums = [rand_this.randint(0, 10) for _ in range(nr * 2)]
+        print(f'Python, ints: {combine_many(nums)} ms')
+        print(f'Rust, ints: {combine_many_rust(nums)} ms')
 
         nums = [rand_this.randint(0, 10) + 0.5 for _ in range(nr * 2)]
-
-        print('Python, floats', combine_many(nums))
-        print('Rust, floats', combine_many_rustfl(nums))
+        print(f'Python, floats: {combine_many(nums)} ms')
+        print(f'Rust, floats: {combine_many_rustfl(nums)} ms')

--- a/intervalues/__init__.py
+++ b/intervalues/__init__.py
@@ -7,7 +7,7 @@ from .base_interval import BaseInterval, UnitInterval, EmptyInterval
 from .base_interval_discrete import BaseDiscreteInterval
 from .combine_intervals import (combine_intervals, combine_intervals_counter, combine_intervals_set,
                                 combine_intervals_meter, combine_intervals_meter_discrete,
-                                combine_intervals_counter_discrete, combine_intervals_set_discrete)
+                                combine_intervals_counter_discrete, combine_intervals_set_discrete, combine_via_rust)
 from .__version__ import __version__
 
 __all__ = ['AbstractInterval', 'AbstractIntervalCollection',
@@ -15,4 +15,5 @@ __all__ = ['AbstractInterval', 'AbstractIntervalCollection',
            'BaseInterval', 'UnitInterval', 'EmptyInterval', 'BaseDiscreteInterval',
            'combine_intervals', 'combine_intervals_set', 'combine_intervals_meter', 'combine_intervals_counter',
            'combine_intervals_meter_discrete', 'combine_intervals_counter_discrete', 'combine_intervals_set_discrete',
+           'combine_via_rust',
            '__version__']

--- a/intervalues/combine_intervals.py
+++ b/intervalues/combine_intervals.py
@@ -4,6 +4,15 @@ from typing import Optional, Sequence
 import intervalues
 from intervalues import interval_meter, base_interval, interval_set
 from itertools import chain, pairwise
+from intervalues_pyrust import combine_intervals_int, combine_intervals_float
+
+
+def combine_via_rust(intervals: Sequence['intervalues.BaseInterval | intervalues.BaseDiscreteInterval'],
+                     nr_digits: int = 0) -> 'intervalues.IntervalMeter':
+    out = combine_intervals_int([x.to_args() + (1.0,) for x in intervals]) if nr_digits == 0 \
+        else combine_intervals_float([x.to_args() + (1.0,) for x in intervals], nr_digits)
+    base_intervals = [intervalues.BaseInterval(x) for x in out]
+    return interval_meter.IntervalMeter(base_intervals, skip_combine=True)
 
 
 def combine_intervals(intervals: Sequence['intervalues.BaseInterval | intervalues.BaseDiscreteInterval'],

--- a/intervalues/combine_intervals.py
+++ b/intervalues/combine_intervals.py
@@ -9,8 +9,10 @@ from intervalues_pyrust import combine_intervals_int, combine_intervals_float
 
 def combine_via_rust(intervals: Sequence['intervalues.BaseInterval | intervalues.BaseDiscreteInterval'],
                      nr_digits: int = 0) -> 'intervalues.IntervalMeter':
-    out = combine_intervals_int([x.to_args() + (1.0,) for x in intervals]) if nr_digits == 0 \
-        else combine_intervals_float([x.to_args() + (1.0,) for x in intervals], nr_digits)
+    out = combine_intervals_int([x.to_args() + (1,) if x.value == 1 else x.to_args()
+                                 for x in intervals]) if nr_digits == 0 \
+        else combine_intervals_float([x.to_args() + (1.0,) if x.value == 1 else x.to_args()
+                                      for x in intervals], nr_digits)
     base_intervals = [intervalues.BaseInterval(x) for x in out]
     return interval_meter.IntervalMeter(base_intervals, skip_combine=True)
 

--- a/intervalues/interval_meter.py
+++ b/intervalues/interval_meter.py
@@ -28,14 +28,22 @@ class IntervalMeter(AbstractIntervalCollection):
     IntervalPdf for sampling purposes.
     """
 
-    def __init__(self, data: Optional[Sequence['intervalues.BaseInterval'] | 'intervalues.BaseInterval'] = None):
+    def __init__(self, data: Optional[Sequence['intervalues.BaseInterval'] | 'intervalues.BaseInterval'] = None,
+                 skip_combine=False):
         super().__init__()
         self.data: Counter = Counter()
         if data is not None:
-            if isinstance(data, collections.abc.Sequence):
-                combine_intervals_meter(data, object_exists=self)
-            elif isinstance(data, base_interval.BaseInterval):
-                self.data[data.as_index()] = data.value  # type: ignore[assignment]
+            if skip_combine:
+                if all(type(x) == intervalues.BaseInterval for x in data):
+                    temp_dict = {x.as_index(): x.value for x in data}
+                    self.data.update(temp_dict)
+                else:
+                    raise TypeError('Can\'t ignore combine due to input not being sequence of BaseIntervals.')
+            else:
+                if isinstance(data, collections.abc.Sequence):
+                    combine_intervals_meter(data, object_exists=self)
+                elif isinstance(data, base_interval.BaseInterval):
+                    self.data[data.as_index()] = data.value  # type: ignore[assignment]
 
     def items(self) -> 'ItemsView':
         return self.data.items()

--- a/tests/test_combine_intervals.py
+++ b/tests/test_combine_intervals.py
@@ -4,6 +4,7 @@ import pytest
 from random import Random
 from intervalues_pyrust import combine_intervals_int, combine_intervals_float
 
+from intervalues.combine_intervals import combine_via_rust
 
 INTERVAL_MANY = [5, 10, 25, 100, 250, 500, 1000, 1000000]
 
@@ -242,5 +243,12 @@ def test_combine_many_randint_rust(nr_intervals):
     assert len(meter) <= 2 * nr_intervals - 1
 
 
-# TODO: add test that rust impl == py impl
-# TODO: add function to convert list of BaseIntervals to input for rust and convert output to IntervalMeter
+@pytest.mark.parametrize("nr_intervals", INTERVAL_MANY)
+def test_combine_rust_to_python(nr_intervals):
+    this_random = Random()
+    nums = [this_random.randint(0, 10) for _ in range(nr_intervals * 2)]
+    intervals = [x + (1, ) if x[0] < x[1] else (x[1], x[0], 1) for x in split_to_pairs(nums) if x[0] != x[1]]
+    intervals = [BaseInterval(interval) for interval in intervals if interval[0] != interval[1]]
+    meter_rust = combine_via_rust(intervals)
+    meter_py = combine_intervals(intervals)
+    assert meter_rust == meter_py


### PR DESCRIPTION
What a bunch of wrappers!

This adds `combine_via_rust` which takes a list of BaseIntervals and converts them to an IntervalMeter aggregated result while doing the calculations behind the scenes in Rust. Example shows speed-up of about a factor 2 (e.g. runtime is about half), both for integers and floats.

Note that for now the default will still be Python-based until this Rust implementation is more stable, tested, and feature-complete. But for speeding up existing use cases it could be used already.