### PR TITLE
0.3.0 post-release update to build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 *.egg-info/
 local/
 .venv
+build/
 
 ### Python template
 .idea

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Compile wheels
+for PYBIN in /opt/python/{cp310,cp311,cp312,cp313,pp310}*/bin; do
+    rm -rf /io/build/
+    "${PYBIN}/pip" install -U setuptools setuptools-rust
+    "${PYBIN}/pip" wheel /io/ -w /io/dist/ --no-deps
+done
+
+# Bundle external shared libraries into the wheels
+for whl in /io/dist/*{cp310,cp311,cp312,cp313,pp310}*.whl; do
+    auditwheel repair "$whl" -w /io/dist/
+done
+
+# Install packages and test
+for PYBIN in /opt/python/{cp310,cp311,cp312,cp313,pp310}*/bin; do
+    "${PYBIN}/pip" install intervalues -f /io/dist/
+done


### PR DESCRIPTION
0.3.0 post-release update to build system
No change to actual Python or Rust code, just to how this is distributed to PyPI because of the manylinux restriction (see comment on #1).

The resulting files have been tested using PyPy 3.10 and Python 3.10.